### PR TITLE
Bump dependencies to latest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
       2,
       "except-parens"
     ],
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "no-debugger": 2,
     "no-empty": 2,
     "no-eval": 2,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "author": "Brian R. Bondy <netzen@gmail.com> (http://www.brianbondy.com)",
   "license": "MPL-2.0",
   "devDependencies": {
-    "babel": "^5.8.23",
     "babel-cli": "^6.1.2",
     "babel-core": "^6.1.2",
     "babel-eslint": "^4.1.3",
@@ -22,7 +21,7 @@
     "babel-polyfill": "^6.0.16",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-stage-2": "^6.1.2",
-    "eslint": "^1.6.0",
+    "eslint": "^2.1.0",
     "mocha": "^2.3.3",
     "pre-commit": "^1.1.2"
   },
@@ -36,7 +35,7 @@
   "homepage": "https://github.com/bbondy/abp-filter-parser#readme",
   "description": "",
   "dependencies": {
-    "bloom-filter-js": "0.0.11"
+    "bloom-filter-js": "0.0.12"
   },
   "engines": {
     "node": "~5.0"


### PR DESCRIPTION
This PR fixes an error with Babel, which is causing the build to error on Travis. It updates an assortment of dependencies as well, including ESLint. I updated a rule that changed with the dependency bump accordingly (`space-after-keywords -> keyword-spacing`).
