### PR TITLE
Fixes for abp-filter-parser

### DIFF
--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -577,7 +577,7 @@ export function matches(parserData, input, contextParams = {}, cachedInputData =
     // Check for exceptions only when there's a match because matches are
     // rare compared to the volume of checks
     let exceptionBloomFilterMiss = parserData.exceptionBloomFilter && !parserData.exceptionBloomFilter.substringExists(cleanedInput, fingerprintSize);
-    if (!exceptionBloomFilterMiss || hasMatchingFilters(parserData.exceptionFilters, parserData, input, contextParams, cachedInputData)) {
+    if (!exceptionBloomFilterMiss && hasMatchingFilters(parserData.exceptionFilters, parserData, input, contextParams, cachedInputData)) {
       cachedInputData.notMatchCount++;
       return false;
     }

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -444,6 +444,13 @@ export function matchesFilter(parsedFilterData, input, contextParams = {}, cache
     return false;
   }
 
+  // For HTML rule selector filters, consider them as matches as long as the
+  // filter options match. This allows us to use this function, for example,
+  // to check whether an HTML rule selector filter applies to a domain or not
+  if (parsedFilterData.htmlRuleSelector) {
+    return true;
+  }
+
   // Check for a regex match
   if (parsedFilterData.isRegex) {
     if (!parsedFilterData.regex) {

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -290,6 +290,11 @@ let exceptionRules = new Map([
        'http://examples.com/#!foo',
      ],
   }],
+  [`/adbanner.
+    @@||advertserve.com/images/aaamidatlantic.advertserve.com/advertpro/servlet/files/$image,domain=midatlantic.aaa.com`, {
+      blocked: ['http://simple-adblock.com/adblocktest/files/adbanner.gif'],
+      notBlocked: [],
+  }],
 ]);
 
 // Map from a key with a ABP filter rule to a set of [testUrl, context params, should block?]
@@ -439,7 +444,7 @@ describe('parser#parse()', function() {
       // Num lines minus (num empty lines + num comment lines)
       assert.equal(parserData.htmlRuleFilters.length, 26465);
       assert.equal(parserData.filters.length + parserData.noFingerprintFilters.length, 18096);
-      assert.equal(parserData.exceptionFilters.length, 2975);
+      assert.equal(parserData.exceptionFilters.length + parserData.noFingerprintExceptionFilters.length, 2975);
       cb();
     });
   });
@@ -457,6 +462,6 @@ describe('parser#parse()', function() {
     assert.equal(parserData.htmlRuleFilters.length, 3);
     assert.equal(parserData.filters.length, 0);
     assert.equal(parserData.noFingerprintFilters.length, 3);
-    assert.equal(parserData.exceptionFilters.length, 3);
+    assert.equal(parserData.exceptionFilters.length + parserData.noFingerprintExceptionFilters.length, 3);
   });
 });


### PR DESCRIPTION
I have been using this project and have found what (AFAIK) is a bug in the exception filter match checks, and also a potential enhancement to the filter match checks to support HTML rule filters (currently unsupported / crashes on call).

All info for reviewing the changes is included in the code/comments/commit logs.

The thing I'm a bit doubtful about in this pull request is the change to cleanedInput. cleanedInput basically contains the URL with the http/https prefix removed, and is used right before checking is a filter matches.
I removed it because if it's present, the test in parser-test.js that includes '@@|http://example.com' as an exception filter fails, because this filter is added with the "http://" prefix in the exception bloom filter. If later, one tries to query against exceptionBloomFilter with cleanedInput, it will NOT match because the http:// prefix has been removed from cleanedInput, so there's no substring match. I don't see how this could work if the prefix is removed, and I can't find any reason to remove the prefix before matching, so I decided to remove this.

Any comments/possible improvements/etc. gladly accepted ;)